### PR TITLE
Removed unnecessary 'mut' for msg argument at the correct function.

### DIFF
--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -60,7 +60,7 @@ impl Decoder {
     /// assert_eq!(&[1, 2, 3, 4], corrected.data())
     /// ```
     pub fn correct(&self,
-                   msg: &mut [u8],
+                   msg: &[u8],
                    erase_pos: Option<&[u8]>)
                    -> Result<Buffer> {
         let mut msg = Buffer::from_slice(msg, msg.len() - self.ecc_len);


### PR DESCRIPTION
Hi mersinvalid,
I removed the `mut` from the msg argument of the correct function. I was confused when I first tried to use this function: I though that it will change the message in place, but I found that the recovered data is returned in a buffer object.

What is your opinion about having a correct function that does the correction in place? I would like to avoid multiple copies when I use it. I might have the time to do this, but I wasn't sure if this is a good idea.

Thank you for this crate, it is very useful for me!
real.
