### PR TITLE
Fix deprecation warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ authors = ["Mike Lubinets <lubinetsm@yandex.ru>"]
 version = "0.2.1"
 
 [dev-dependencies]
-rustc-serialize = "0.3"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [features]
 unsafe_indexing = []

--- a/examples/bandwidth.rs
+++ b/examples/bandwidth.rs
@@ -1,5 +1,12 @@
+extern crate serde;
+extern crate serde_json;
 extern crate reed_solomon;
-extern crate rustc_serialize;
+
+use std::thread;
+use std::time::Duration;
+use std::sync::mpsc;
+
+use serde::{Serialize};
 
 use reed_solomon::Encoder;
 use reed_solomon::Decoder;
@@ -23,10 +30,6 @@ impl Iterator for Generator {
         Some(self.num)
     }
 }
-
-use std::thread;
-use std::time::Duration;
-use std::sync::mpsc;
 
 // Returns MB/s
 fn encoder_bandwidth(data_len: usize, ecc_len: usize) -> f32 { 
@@ -92,7 +95,7 @@ fn decoder_bandwidth(data_len: usize, ecc_len: usize, errors: usize) -> f32 {
     kbytes / 1024.0
 } 
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct BenchResult {
     data_len: usize,
     ecc_len: usize,
@@ -100,12 +103,12 @@ struct BenchResult {
     decoder: Vec<DecoderResult>
 } 
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct EncoderResult {
     bandwidth: f32
 }
 
-#[derive(RustcEncodable)]
+#[derive(Serialize)]
 struct DecoderResult {
     errors: usize,
     bandwidth: f32
@@ -129,6 +132,6 @@ fn main() {
         }
     }).collect();
 
-    let json = rustc_serialize::json::encode(&results).unwrap();
+    let json = serde_json::to_string(&results).unwrap();
     println!("{}", json);
 }

--- a/src/decoder.rs
+++ b/src/decoder.rs
@@ -89,8 +89,8 @@ impl Decoder {
         }
 
         let fsynd = self.forney_syndromes(&synd, erase_pos, msg.len());
-        let err_loc = try!(self.find_error_locator(&fsynd, None, erase_pos.len()));
-        let mut err_pos = try!(self.find_errors(&err_loc.reverse(), msg.len()));
+        let err_loc = self.find_error_locator(&fsynd, None, erase_pos.len())?;
+        let mut err_pos = self.find_errors(&err_loc.reverse(), msg.len())?;
 
         // Append erase_pos to err_pos
         for x in erase_pos.iter() {


### PR DESCRIPTION
This fixes the deprecation warnings you get when building or running the examples.

The original warnings i got when running `cargo run --release --example bandwidth` were these: 

```
Updating crates.io index
   Compiling rustc-serialize v0.3.24
   Compiling reed-solomon v0.2.1 (/media/progg/projects/reed-solomon-rs)
warning: use of deprecated macro `try`: use the `?` operator instead
  --> src/decoder.rs:92:23
   |
92 |         let err_loc = try!(self.find_error_locator(&fsynd, None, erase_pos.len()));
   |                       ^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated macro `try`: use the `?` operator instead
  --> src/decoder.rs:93:27
   |
93 |         let mut err_pos = try!(self.find_errors(&err_loc.reverse(), msg.len()));
   |                           ^^^

warning: `reed-solomon` (lib) generated 2 warnings
warning: use of deprecated macro `RustcEncodable`: rustc-serialize is deprecated and no longer supported
  --> examples/bandwidth.rs:95:10
   |
95 | #[derive(RustcEncodable)]
   |          ^^^^^^^^^^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

warning: use of deprecated macro `RustcEncodable`: rustc-serialize is deprecated and no longer supported
   --> examples/bandwidth.rs:103:10
    |
103 | #[derive(RustcEncodable)]
    |          ^^^^^^^^^^^^^^

warning: use of deprecated macro `RustcEncodable`: rustc-serialize is deprecated and no longer supported
   --> examples/bandwidth.rs:108:10
    |
108 | #[derive(RustcEncodable)]
    |          ^^^^^^^^^^^^^^

warning: `reed-solomon` (example "bandwidth") generated 3 warnings
    Finished release [optimized] target(s) in 3.75s


```

I just replaced evrey occurence of try! with ? and swapped rustc-serialize with serde. 

